### PR TITLE
error checking

### DIFF
--- a/cImage.py
+++ b/cImage.py
@@ -52,6 +52,12 @@ which serves a similar purpose in the graphics primitive world.
 # Brad Miller
 # distribute on pypi
 #
+# Version 1.5 May 2016 Max Hailperin <max@gustavus.edu>
+# Changes:
+#   Add more checks of parameter types and ranges so error messages are
+#     closer to the user's code and more intelligible.
+#   Disable the ability of Pixels to range up to 1.0 instead of 255, which
+#     didn't seem used and would make the type checking more complex.
 
 try:
     import tkinter
@@ -151,10 +157,10 @@ class Pixel(object):
     """This simple class abstracts the RGB pixel values."""
     def __init__(self, red, green, blue):
         super(Pixel, self).__init__()
-        self.__red = red
-        self.__green = green
-        self.__blue = blue
         self.max = 255
+        self.setRed(red)
+        self.setGreen(green)
+        self.setBlue(blue)
 
     def getRed(self):
         """Return the red component of the pixel"""
@@ -174,21 +180,27 @@ class Pixel(object):
 
     def setRed(self,red):
         """Modify the red component"""
-        if self.max >= red >= 0:
+        if not isinstance(red, int):
+            raise TypeError("Error:  pixel value %r is not an integer" % red)
+        elif self.max >= red >= 0:
             self.__red = red
         else:
             raise ValueError("Error:  pixel value %d is out of range" % red)
 
     def setGreen(self,green):
         """Modify the green component"""
-        if self.max >= green >= 0:
+        if not isinstance(green, int):
+            raise TypeError("Error:  pixel value %r is not an integer" % green)
+        elif self.max >= green >= 0:
             self.__green = green
         else:
             raise ValueError("Error:  pixel value %d is out of range" % green)
 
     def setBlue(self,blue):
         """Modify the blue component"""
-        if self.max >= blue >= 0:
+        if not isinstance(blue, int):
+            raise TypeError("Error:  pixel value %r is not an integer" % blue)
+        elif self.max >= blue >= 0:
             self.__blue = blue
         else:
             raise ValueError("Error:  pixel value %d is out of range" % blue)
@@ -213,6 +225,10 @@ class Pixel(object):
     def setRange(self,pmax):
         """docstring for setRange"""
         if pmax == 1.0:
+            raise ValueError("Range of 1.0 is not currently supported")
+            # This raising of an error was inserted  in conjunction with
+            # requiring the values to be integers, which is necessary for
+            # formatPixel to work correctly. Was 1.0 ever used?
             self.max = 1.0
         elif pmax == 255:
             self.max = 255
@@ -441,6 +457,8 @@ class AbstractImage(object):
 
 class FileImage(AbstractImage):
     def __init__(self,thefile):
+        if not isinstance(thefile, str):
+            raise TypeError("Error: file name %r not a string" % thefile)
         super(FileImage, self).__init__(fname = thefile)
 
 class Image(FileImage):
@@ -448,10 +466,21 @@ class Image(FileImage):
 
 class EmptyImage(AbstractImage):
     def __init__(self,cols,rows):
+        if not isinstance(cols, int):
+            raise TypeError("Error: width %r not an integer" % cols)
+        if cols <= 0:
+            raise ValueError("Error: width %d not positive" % cols)
+        if not isinstance(rows, int):
+            raise TypeError("Error: height %r not an integer" % rows)
+        if rows <= 0:
+            raise ValueError("Error: height %d not positive" % rows)
         super(EmptyImage, self).__init__(height = rows, width = cols)
 
 class ListImage(AbstractImage):
     def __init__(self,thelist):
+        # Note that the corresponding code in AbstractImage doesn't work
+        # so apparently ListImage isn't used. As such, there doesn't seem
+        # to be much point in adding error checking.
         super(ListImage, self).__init__(data=thelist)
 
 # Example program  Read in an image and calulate the negative.

--- a/cImage.py
+++ b/cImage.py
@@ -58,6 +58,12 @@ which serves a similar purpose in the graphics primitive world.
 #     closer to the user's code and more intelligible.
 #   Disable the ability of Pixels to range up to 1.0 instead of 255, which
 #     didn't seem used and would make the type checking more complex.
+#
+# Version 1.6 May 2016 Max Hailperin <max@gustavus.edu>
+# Changes:
+#   Add autoShow function that can be used to get and optionally set a flag
+#     that if True makes images automatically be displayed when their printed
+#     representation is produced (e.g. as results in the shell).
 
 try:
     import tkinter
@@ -87,6 +93,17 @@ _imroot.lift()
 #_imroot.call('wm', 'attributes', '.', '-topmost', True)
 #_imroot.after_idle(_imroot.call, 'wm', 'attributes', '.', '-topmost', False)
 
+
+# For backward compatibility, the new autoShow feature is off by default:
+autoShowOn = False
+
+def autoShow(newSetting=None):
+    """Return and optionally change the True/False autoShow setting"""
+    global autoShowOn
+    oldSetting = autoShowOn
+    if newSetting != None:
+        autoShowOn = newSetting
+    return oldSetting
 
 def formatPixel(data):
     if type(data) == tuple:
@@ -453,6 +470,13 @@ class AbstractImage(object):
             for j in range(self.width):
                 res[i].append(self.getPixel(j,i))
         return res
+
+    def __repr__(self):
+        r = super(AbstractImage, self).__repr__()
+        if autoShowOn:
+            w = ImageWin(r, self.width, self.height)
+            self.draw(w)
+        return r
 
 
 class FileImage(AbstractImage):


### PR DESCRIPTION
I've added code to check parameter types and value ranges so that users get more intelligible error messages more closely associated with their own code. We were particularly seeing problems with the Pixel constructor, which wasn't even doing the same checks as setRed etc. However, I went beyond that. To simplify the type checking, I disabled the feature whereby Pixel instances could be set to a range of 1.0 rather than 255. As far as I could tell this wasn't used.

The second commit (26f0d53) adds a new feature whereby when images are displayed as values in the shell, a window can automatically pop up showing the image. This reduces the cognitive burden on students, allowing them to focus on just the image classes (and Pixel) without needing to worry about ImageWin. Functions like pixelMapper that operate on images can be tried out in the shell just like functions on any other type of values without needing the drawing step. This only works if the platform environment is such that exitOnClick isn't needed. The feature is turned off by default but can be turned on using autoShow(True)
